### PR TITLE
Fix query selector of pixiv extractor

### DIFF
--- a/xpi/chrome/content/library/extractors.js
+++ b/xpi/chrome/content/library/extractors.js
@@ -1297,7 +1297,7 @@ this.Extractors = Extractors = Tombfix.Service.extractors = new Repository([
 				// mode=big and mode=manga_big on login
 				'body > img:only-child',
 				// mode=manga
-				'.image',
+				'img.image',
 				// non-r18 illust on logout
 				'.cool-work-main > .img-container > a.medium-image > img',
 				// r18 on logout


### PR DESCRIPTION
ログイン中にboothの商品があるイラストページにアクセスすると、boothの商品の表示部分が、
querySelectorにひっかかり、本来期待していない値が取れてしまうのを修正。

e.g. http://www.pixiv.net/member_illust.php?mode=medium&illust_id=48854882

修正前の値: 
```
<a class="image" target="_blank" href="https://wogura.booth.pm/items/36117?utm_source=pixiv&amp;utm_medium=promotion&amp;utm_content=work-item&amp;utm_campaign=pixiv-promotion">
  <img alt="" src="https://s.booth.pm/5a6612b2-b997-45ed-aa68-bfda37fb96d6/i/36117/76ff869f-8a7e-4a26-acec-bcea9fa2eb85_f_150x150.jpg">
</a>
```

修正後の値:
```
<img alt="" src="http://i3.pixiv.net/c/150x150/img-master/img/2015/02/20/00/51/52/48854882_p0_master1200.jpg">
```