### PR TITLE
Fix image url attribute path of pixiv extractor

### DIFF
--- a/xpi/chrome/content/library/extractors.js
+++ b/xpi/chrome/content/library/extractors.js
@@ -1289,7 +1289,7 @@ this.Extractors = Extractors = Tombfix.Service.extractors = new Repository([
 		getInfo : function (ctx, illustID, doc = ctx.document) {
 			var isUgoira = this.isUgoiraPage({document : doc}),
 				img = this.getImageElement({document : doc}, illustID),
-				url = img ? img.src : '',
+				url = img ? (img.src || img.dataset.src) : '',
 				info =  {
 					imageURL  : url,
 					pageTitle : doc.title,


### PR DESCRIPTION
ここ数日のpixivの仕様変更でイラストページ上のサムネイル画像を取得する際に、
<code>\<img src="PIXIV_THUMBNAIL_URL"\></code>となっていたものが、
<code>\<img data-src="PIXIV_THUMBNAIL_URL"\></code>に変更になったようです。

ひと通りのタイプのページを確認しましたが、漫画のイラストページの場合には、
今までどおり<code>img.src</code>に入ってるようですので、<code>img.src</code>が空の場合には、
<code>img.dataset.src</code>を使用するような形にしました。