### PR TITLE
Rename String.prototype.contains to includes

### DIFF
--- a/xpi/chrome/content/quickPostForm.js
+++ b/xpi/chrome/content/quickPostForm.js
@@ -42,7 +42,7 @@ function DialogPanel(position, message){
 
   // 不可視にして描画を隠す
   // #14 Linuxの場合は透明から復帰できない問題があるため透明にしない
-  if(!navigator.platform.contains('Linux'))
+  if(!navigator.platform.includes('Linux'))
     self.elmWindow.style.opacity = 0;
 
   if (getPref('model.twitter.showTweetLength')) {


### PR DESCRIPTION
Firefox 48.0a2 でポストフォームを表示した際に `String.prototype.contains` が存在しないためエラーが発生しています。

`String.prototype.contains` は Firefox 40 で `includes` に改名され、 Firefox 48 で `contains` が削除されたようです。

* https://www.fxsitecompat.com/docs/2015/string-prototype-contains-has-been-renamed-to-includes/
* https://www.fxsitecompat.com/docs/2016/string-prototype-contains-has-been-removed-in-favour-of-includes/